### PR TITLE
Error when where clause is blank

### DIFF
--- a/lib/condition-builder.js
+++ b/lib/condition-builder.js
@@ -82,6 +82,7 @@ module.exports = function(where, table, values){
 
   // Always remove outer-most parenthesis
   var result = buildConditions(where, '$equals');
+  if (!result) return '';
   if (result[0] == '(') return result.substring(1, result.length - 1);
   return result;
 };

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -640,4 +640,17 @@ describe('Conditions', function(){
     , [2, 3]
     );
   });
+
+  it ('Should have no conditions if where is an empty object', function(){
+    var query = builder.sql({
+      type: 'select'
+    , table: 'users'
+    , where: {}
+    });
+
+    assert.equal(
+      query.toString()
+    , 'select "users".* from "users"'
+    );
+  });
 });


### PR DESCRIPTION
If you make a query like this:

``` javascript
{
  ...
  where: {}
  ...
}
```

It will result in:

```
TypeError: Cannot read property '0' of undefined
    at module.exports (mongo-sql/lib/condition-builder.js:85:13)
```
