### PR TITLE
Use local install of mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "./node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",
@@ -21,5 +21,8 @@
     "sql"
   ],
   "author": "John Fawcett",
-  "license": "BSD"
+  "license": "BSD",
+  "devDependencies": {
+    "mocha": "~1.12.0"
+  }
 }


### PR DESCRIPTION
Relying on mocha to be installed globally isn't really needed, as you can path
it directly to the node-modules folder.  This will come in hand for travis integration
as well.
