### PR TITLE
Multiple alter column statements

### DIFF
--- a/docs/action-helpers.md
+++ b/docs/action-helpers.md
@@ -230,7 +230,7 @@ alter column
   [set storage value.storage]
 ```
 
-__Expects:__ ```object```
+__Expects:__ ```object|array```
 
 Alter a column. Passing ```notNull: true``` will return set not null, but ```notNull: false``` return drop not null, everything else follows the format above.
 
@@ -251,6 +251,29 @@ __Example:__
 
 ```sql
 alter table "users" alter column "createdAt" drop not null
+```
+
+If you need to do multiple alter column statements, you can just pass an array of alterColumn objects:
+
+```javascript
+{
+  type: 'alter-table'
+, table: 'users'
+, action: {
+    alterColumn: [
+      { name: 'createdAt', storage: 'external' }
+    , { name: 'createdAt', notNull: true }
+    , { name: 'createdAt', default: 'now()' }
+    ]
+  }
+}
+```
+
+```sql
+alter table "users"
+  alter column "createdAt" set storage external,
+  alter column "createdAt" set not null,
+  alter column "createdAt" set default now();
 ```
 
 ### Helper: 'dropConstraint'

--- a/helpers/actions.js
+++ b/helpers/actions.js
@@ -126,6 +126,12 @@ define(function(require, exports, module){
   });
 
   actions.add('alterColumn', function(value, values, query){
+    if ( Array.isArray(value) ){
+      return value.map( function( v ){
+        return actions.get('alterColumn').fn( v, values, query );
+      }).join(', ');
+    }
+
     var output = ["alter column"];
 
     output.push( utils.quoteColumn(value.name) );

--- a/test/alter-table.js
+++ b/test/alter-table.js
@@ -633,6 +633,29 @@ describe('Built-In Query Types', function(){
           ].join('')
         );
       });
+
+      it('should perform multiple alter columns', function(){
+        var query = builder.sql({
+          type: 'alter-table'
+        , table: 'users'
+        , action: {
+            alterColumn: [
+              { name: 'createdAt', storage: 'external' }
+            , { name: 'createdAt', notNull: true }
+            , { name: 'createdAt', default: 'now()' }
+            ]
+          }
+        });
+
+        assert.equal(
+          query.toString()
+        , [ 'alter table "users" '
+          , 'alter column "createdAt" set storage external, '
+          , 'alter column "createdAt" set not null, '
+          , 'alter column "createdAt" set default now()'
+          ].join('')
+        );
+      });
     });
 
     describe('add/drop constraint', function(){


### PR DESCRIPTION
Alter table statements can have multiple, comma separated alter column statements.

http://www.postgresql.org/docs/9.2/static/sql-altertable.html
