### PR TITLE
Dates not handled correctly in update where clause

### DIFF
--- a/lib/condition-builder.js
+++ b/lib/condition-builder.js
@@ -27,7 +27,7 @@ define(function(require, exports, module){
           continue;
         }
 
-        if (typeof where[key] == 'object'){
+        if (typeof where[key] == 'object' && !(where[key] instanceof Date)){
 
           // Key is conditional block
           if (helpers.has(key)){

--- a/test/regression.js
+++ b/test/regression.js
@@ -1,0 +1,40 @@
+/**
+ * Regression Tests
+ */
+
+var assert = require('assert');
+var builder = require('../');
+
+describe('Regression Tests', function(){
+
+  describe('Conditional builder', function(){
+
+    it ('should treat dates as a value', function(){
+      var query = builder.sql({
+        type: 'update',
+        table: 'blah',
+        values: {name: 'brian'},
+        where: {
+          id: 1,
+          birthday: new Date()
+        }
+      });
+
+      assert.equal(
+        query.toString()
+      , 'update "blah" set "name" = $1 where "blah"."id" = $2 and "blah"."birthday" = $3'
+      );
+
+      assert.deepEqual(
+        query.values
+      , [
+          query.original.values.name
+        , query.original.where.id
+        , query.original.where.birthday
+        ]
+      );
+    });
+
+  });
+
+});


### PR DESCRIPTION
Consider this:

``` js
var sql = require('mongo-sql').sql

var query = sql({
  type: 'update',
  table: 'blah',
  values: {name: 'brian'},
  where: {
    id: 1,
    birthday: new Date()
  }
})

console.log(query.toQuery())
```

The actual output from this is:

``` sh
{ text: 'update "blah" set "name" = $1 where "blah"."id" = $2',
  values: [ 'brian', 1 ] }
```

Unfortunately in my scenario I have a table with a primary key of (id, date) and so using mongo-sql updated all records for the ID instead of just the one for the given (id, date) pair. :frowning: 

Am I missing something here or are dates just not supported at the moment?
