### PR TITLE
Casts + JSON derefs are malformed during the automated quoting

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,8 +6,9 @@ if (typeof module === 'object' && typeof define !== 'function') {
 
 define(function(require, exports, module){
   var utils = module.exports = {};
-  var regexes = {
+  var regs = {
     dereferenceOperators: /[-#=]+>+/g
+  , endsInCast: /::\w+$/
   };
 
   utils.parameterize = function(value, values){
@@ -20,13 +21,21 @@ define(function(require, exports, module){
   utils.quoteColumn =  function(field, collection){
     var period;
 
+    // They're casting
+    if ( regs.endsInCast.test( field ) ){
+      return utils.quoteColumn(
+        field.replace( regs.endsInCast, '' )
+      , collection
+      ) + field.match( regs.endsInCast )[0];
+    }
+
     // They're using JSON/Hstore operators
-    if ( regexes.dereferenceOperators.test( field ) ){
-      var operators = field.match( regexes.dereferenceOperators );
+    if ( regs.dereferenceOperators.test( field ) ){
+      var operators = field.match( regs.dereferenceOperators );
 
       // Split on operators
       return field.split(
-        regexes.dereferenceOperators
+        regs.dereferenceOperators
       // Properly quote each part
       ).map( function( part, i ){
         if ( i === 0 ) return utils.quoteColumn( part, collection );
@@ -40,12 +49,6 @@ define(function(require, exports, module){
       }).reduce( function( a, b, i ){
         return [ a, b ].join( operators[ i - 1 ] );
       });
-    }
-
-    // They're casting
-    if ( field.indexOf('::') > -1 ){
-      field = field.split('::');
-      return utils.quoteColumn( field[0], collection ) + '::' + field[1];
     }
 
     // Just using *, no collection

--- a/test/regression.js
+++ b/test/regression.js
@@ -35,6 +35,26 @@ describe('Regression Tests', function(){
       );
     });
 
+    it ('should not improperly quote cast', function(){
+      var query = builder.sql({
+        type: 'select',
+        table: 'blah',
+        where: {
+          'data->id::integer': 7
+        }
+      });
+
+      assert.equal(
+        query.toString()
+      , 'select "blah".* from "blah" where "blah"."data"->\'id\'::integer = $1'
+      );
+
+      assert.deepEqual(
+        query.values
+      , [7]
+      );
+    });
+
   });
 
 });


### PR DESCRIPTION
If you do `{'data->>name::integer': 'Bob'}` you wind up with `"users"."data"->>'name::integer'`.

Here's the code I'm using to correct it now:

``` javascript
// Cast? Pre-quote so mongo-sql wont handle (it behaves incorrectly when json derefs are used)
// (by default, you'll get "gui_jsons"."doc"->>'foo::integer' when you need "gui_jsons"."doc"->>'foo'::integer)
if (column2.indexOf('::') !== -1) {
  column2 = '("gui_jsons".'+column2.replace(/(->>?)([^:->]*)(::)/, function(v, a, b, c) { return a+'\''+b+'\')'+c; });
}
```

So it can be solved with `{'("gui_jsons".data->>\'name\')::integer': 'Bob'}`, but I don't want to accept quotes in user input so I'm changing it manually.

Is this correctable within mosql?
