### PR TITLE
Parameterize Expression Helper

### DIFF
--- a/docs/query-types.md
+++ b/docs/query-types.md
@@ -200,6 +200,99 @@ __Example__:
 }
 ```
 
+### Type: 'union'
+
+Combines multiple queries via the `union` operation. See [queries helper](./query-helpers.md#helper-queries) for more information. Works the same as the [intersect](#type-intersect) and [except](#type-except) types.
+
+__Definition:__
+
+```
+{queries}
+```
+
+__Helpers Used:__ [queries](./query-helpers.md#helper-queries)
+
+__Example__:
+
+```javascript
+{
+  type: 'union'
+, all: true
+, queries: [
+    { type: 'select', table: 'users' }
+  , { type: 'select', table: 'other_users' }
+  ]
+};
+```
+
+__Result:__
+
+```sql
+select "users".* from "users" union all select "other_users".* from "other_users"
+```
+
+### Type: 'intersect'
+
+Combines multiple queries via the `intersect` operation. See [queries helper](./query-helpers.md#helper-queries) for more information. Works the same as the [union](#type-union) and [except](#type-except) types.
+
+__Definition:__
+
+```
+{queries}
+```
+
+__Helpers Used:__ [queries](./query-helpers.md#helper-queries)
+
+__Example__:
+
+```javascript
+{
+  type: 'intersect'
+, all: true
+, queries: [
+    { type: 'select', table: 'users' }
+  , { type: 'select', table: 'other_users' }
+  ]
+};
+```
+
+__Result:__
+
+```sql
+select "users".* from "users" intersect all select "other_users".* from "other_users"
+```
+
+### Type: 'except'
+
+Combines multiple queries via the `except` operation. See [queries helper](./query-helpers.md#helper-queries) for more information. Works the same as the [intersect](#type-intersect) and [union](#type-union) types.
+
+__Definition:__
+
+```
+{queries}
+```
+
+__Helpers Used:__ [queries](./query-helpers.md#helper-queries)
+
+__Example__:
+
+```javascript
+{
+  type: 'except'
+, all: true
+, queries: [
+    { type: 'select', table: 'users' }
+  , { type: 'select', table: 'other_users' }
+  ]
+};
+```
+
+__Result:__
+
+```sql
+select "users".* from "users" except all select "other_users".* from "other_users"
+```
+
 ## Adding Your Own Query Types
 
 MoSQL uses the same interface as its API consumers to build functionality.

--- a/helpers/query-types.js
+++ b/helpers/query-types.js
@@ -54,6 +54,21 @@ define(function(require, exports, module){
   , 'create {orReplace} {temporary} view {view} {columns} as {expression}'
   );
 
+  queryTypes.add(
+    'union'
+  , '{queries}'
+  );
+
+  queryTypes.add(
+    'intersect'
+  , '{queries}'
+  );
+
+  queryTypes.add(
+    'except'
+  , '{queries}'
+  );
+
   queryTypes.add('function', '{function}( {expression} )');
   queryTypes.add('expression', '{expression}');
 });

--- a/helpers/query/boolean-helpers.js
+++ b/helpers/query/boolean-helpers.js
@@ -7,8 +7,9 @@ if (typeof module === 'object' && typeof define !== 'function') {
 define(function(require, exports, module){
   var helpers = require('../../lib/query-helpers');
   var bools = {
-    orReplace: 'or replace'
-  , temporary: 'temporary'
+    orReplace:  'or replace'
+  , temporary:  'temporary'
+  , all:        'all'
   };
 
   Object.keys( bools ).forEach( function( key ){
@@ -16,8 +17,6 @@ define(function(require, exports, module){
       return bool ? bools[ key ] : '';
     });
   });
-
-
 
   return module.exports;
 });

--- a/helpers/query/queries.js
+++ b/helpers/query/queries.js
@@ -1,0 +1,31 @@
+if (typeof module === 'object' && typeof define !== 'function') {
+  var define = function(factory) {
+    module.exports = factory(require, exports, module);
+  };
+}
+
+define(function(require, exports, module){
+  var helpers = require('../../lib/query-helpers');
+  var queryBuilder = require('../../lib/query-builder');
+
+  helpers.register( 'queries', function( queries, values, query ){
+    var allowedCombinations = [ 'union', 'intersect', 'except' ];
+    var joiner = query.joiner || ' ';
+
+    if ( allowedCombinations.indexOf( query.type ) > -1 ){
+      joiner = query.type;
+
+      if ( query.all ){
+        joiner += ' ' + helpers.get('all').fn( query.all, values, query );
+      }
+
+      joiner = ' ' + joiner + ' ';
+    }
+
+    return queries.map( function( q ){
+      return queryBuilder( q, values );
+    }).join( joiner );
+  });
+
+  return module.exports;
+});

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ define(function(require, exports, module){
   require('./helpers/query/partition');
   require('./helpers/query/over');
   require('./helpers/query/window');
+  require('./helpers/query/queries');
 
   // Register conditional helpers
   require('./helpers/conditional');

--- a/test/combining-queries.js
+++ b/test/combining-queries.js
@@ -1,0 +1,79 @@
+var assert  = require('assert');
+var builder = require('../');
+
+describe ('Combining Queries', function(){
+  it ('should union', function(){
+    var query = builder.sql({
+      type: 'union'
+    , queries: [
+        { type: 'select', table: 'users' }
+      , { type: 'select', table: 'other_users' }
+      , { type: 'select', table: 'other_users2' }
+      ]
+    });
+
+    assert.equal(
+      query.toString()
+    , [
+        'select "users".* from "users"'
+      , 'select "other_users".* from "other_users"'
+      , 'select "other_users2".* from "other_users2"'
+      ].join(' union ')
+    );
+  });
+
+  it ('should union all', function(){
+    var query = builder.sql({
+      type: 'union'
+    , all: true
+    , queries: [
+        { type: 'select', table: 'users' }
+      , { type: 'select', table: 'other_users' }
+      ]
+    });
+
+    assert.equal(
+      query.toString()
+    , [
+        'select "users".* from "users"'
+      , 'select "other_users".* from "other_users"'
+      ].join(' union all ')
+    );
+  });
+
+  it ('should intersect', function(){
+    var query = builder.sql({
+      type: 'intersect'
+    , queries: [
+        { type: 'select', table: 'users' }
+      , { type: 'select', table: 'other_users' }
+      ]
+    });
+
+    assert.equal(
+      query.toString()
+    , [
+        'select "users".* from "users"'
+      , 'select "other_users".* from "other_users"'
+      ].join(' intersect ')
+    );
+  });
+
+  it ('should except', function(){
+    var query = builder.sql({
+      type: 'except'
+    , queries: [
+        { type: 'select', table: 'users' }
+      , { type: 'select', table: 'other_users' }
+      ]
+    });
+
+    assert.equal(
+      query.toString()
+    , [
+        'select "users".* from "users"'
+      , 'select "other_users".* from "other_users"'
+      ].join(' except ')
+    );
+  });
+});


### PR DESCRIPTION
``` javascript
{
  type: 'select'
, table: 'users'
, columns: [
    { expression: 'some_col - $1', values: [ 27 ], alias: 'foo' }
  , { expression: 'some_col - $1 - $2', values: [ 32, 33 ], alias: 'bar' }
  ]
, where: {
    id: { $gt: 100 }
  }
}

// => select some_col - $1 as "foo", some_col - $2 - $3 as "bar"
// => from "users" where "users"."id" > $4
```
