### PR TITLE
Parameterize Expression Helper

### DIFF
--- a/docs/query-helpers.md
+++ b/docs/query-helpers.md
@@ -265,6 +265,20 @@ In certain situations, you may want to surround your expression in parenthesis. 
 }
 ```
 
+Expressions can also be parameterized within the grander query:
+
+```javascript
+// => select $1, $2 from "tbl" where "tbl"."col" = $3
+{
+  type: 'select'
+, table: 'tbl'
+, columns: [
+    { expression: { expression: '$1, $2', values: [ 3, 4 ] } }
+  ]
+, where: { col: 'bob' }
+}
+```
+
 [Playground](http://mosql.j0.hn/#/snippets/16)
 
 See the [columns helper examples](#helper-columns) for more uses of expression.

--- a/helpers/query/expression.js
+++ b/helpers/query/expression.js
@@ -13,11 +13,22 @@ define(function(require, exports, module){
     if (query.type == 'insert' && typeof exp == 'object')
       return '(' + queryBuilder(exp, values) + ')';
     if (typeof exp == 'object'){
-      return [
+      var val = [
         exp.parenthesis === true ? '( ' : ''
       , queryBuilder(exp, values)
       , exp.parenthesis === true ? ' )' : ''
       ].join('');
+
+      if (Array.isArray(exp.values)){
+        for (var i = 0, l = exp.values.length; i < l; ++i){
+          val = val.replace(
+            RegExp('(\\$)' + (i+1) + '(\\W|$)','g')
+          , '$1' + values.push(exp.values[i]) + '$2'
+          );
+        }
+      }
+
+      return val;
     }
     return exp;
   });

--- a/test/select.js
+++ b/test/select.js
@@ -604,6 +604,27 @@ describe('Built-In Query Types', function(){
       );
     });
 
+    it ('select expression with parameters', function(){
+      var query = builder.sql({
+        type: 'select'
+      , table: 'tbl'
+      , columns: [
+          { expression: { expression: '$1, $2', values: [ 3, 4 ] } }
+        ]
+      , where: { col: 'bob' }
+      });
+
+      assert.equal(
+        query.toString()
+      , 'select $1, $2 from "tbl" where "tbl"."col" = $3'
+      );
+
+      assert.deepEqual(
+        query.values
+      , [ 3, 4, 'bob' ]
+      );
+    });
+
     // TODO: make this test pass
     // it ('should allow an empty over clause with string', function() {
     //   var query = builder.sql({


### PR DESCRIPTION
``` javascript
{
  type: 'select'
, table: 'users'
, columns: [
    { expression: 'some_col - $1', values: [ 27 ], alias: 'foo' }
  , { expression: 'some_col - $1 - $2', values: [ 32, 33 ], alias: 'bar' }
  ]
, where: {
    id: { $gt: 100 }
  }
}

// => select some_col - $1 as "foo", some_col - $2 - $3 as "bar"
// => from "users" where "users"."id" > $4
```
