### PR TITLE
Schema support {type:'boolean',default:false}

### DIFF
--- a/helpers/column-definitions.js
+++ b/helpers/column-definitions.js
@@ -67,7 +67,7 @@ defs.add('unique', function(unique, values, query){
 });
 
 defs.add('default', function(def, values, query){
-  return def ? ('default ' + def) : '';
+  return def !== undefined ? ('default ' + def) : '';
 });
 
 defs.add('check', function(check, values, query){

--- a/helpers/query/column-constraint.js
+++ b/helpers/query/column-constraint.js
@@ -32,7 +32,7 @@ helpers.register('columnConstraint', function(constraint, values, query){
     output.push( columnDefs.get('noInherit', true, values, query) );
 
   // Default expression
-  if (constraint.default)
+  if ('default' in constraint)
     output.push( columnDefs.get('default').fn(constraint.default, values, query) );
 
   // Unique

--- a/test/create-table.js
+++ b/test/create-table.js
@@ -238,5 +238,37 @@ describe('Built-In Query Types', function(){
         ].join('')
       );
     });
+
+    it('Should default to false', function(){
+      var query = builder.sql({
+        type: 'create-table'
+      , table: 'posts'
+      , definition: {
+          id: {
+            type: 'serial'
+          }
+
+        , content: {
+            type: 'text'
+          }
+
+        , deleted: {
+            type: 'boolean'
+          , default: false
+          }
+        }
+      });
+      console.log(query.toString());
+      assert.equal(
+        query.toString()
+      , [ 'create table "posts" ('
+        , '"id" serial, '
+        , '"content" text, '
+        , '"deleted" boolean default false'
+        , ')'
+        ].join('')
+      );
+    });
+
   });
 });


### PR DESCRIPTION
I added one test and passed all unit tests when I run glup-watch. But I can't run glup even in clean clone.
The error messages are 
```
[22:11:40] Starting 'browser-tests'...
TypeError: 'undefined' is not a function (evaluating 'mocha.useColors(config.useColors)')

  phantomjs://webpage.evaluate():2
  phantomjs://webpage.evaluate():10
  phantomjs://webpage.evaluate():10
[22:11:41] 'browser-tests' errored after 1.16 s
[22:11:41] Error in plugin 'gulp-mocha-phantomjs'
test failed
[22:11:41] 'default' errored after 2.92 s
[22:11:41] Error: [object Object]
    at formatError (/usr/local/lib/node_modules/gulp/bin/gulp.js:169:10)
    at Gulp.<anonymous> (/usr/local/lib/node_modules/gulp/bin/gulp.js:195:15)
    at Gulp.emit (events.js:129:20)
    at Gulp.Orchestrator._emitTaskDone (/Users/newlix/Desktop/mongo-sql/node_modules/gulp/node_modules/orchestrator/index.js:264:8)
    at /Users/newlix/Desktop/mongo-sql/node_modules/gulp/node_modules/orchestrator/index.js:275:23
    at finish (/Users/newlix/Desktop/mongo-sql/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:21:8)
    at cb (/Users/newlix/Desktop/mongo-sql/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:29:3)
    at finish (/Users/newlix/Desktop/mongo-sql/node_modules/run-sequence/index.js:38:5)
    at Gulp.onError (/Users/newlix/Desktop/mongo-sql/node_modules/run-sequence/index.js:45:4)
    at Gulp.emit (events.js:129:20)
```
