### PR TITLE
Functions not working on  Update query

### DIFF
--- a/helpers/query/updates.js
+++ b/helpers/query/updates.js
@@ -1,16 +1,23 @@
-
 var queryTypes = require('../../lib/query-helpers');
 var updateHelpers = require('../../lib/update-helpers');
 var utils = require('../../lib/utils');
+var queryBuilder = require('../../lib/query-builder');
 
 queryTypes.register('updates', function($updates, values, query){
   var output = "set ";
 
   var result = Object.keys( $updates ).map( function( key ){
-    if (updateHelpers.has(key))
+    if (updateHelpers.has(key)){
       return updateHelpers.get(key).fn($updates[key], values, query.__defaultTable);
-    if ($updates[key] === null)
+    }
+
+    if ($updates[key] === null){
       return utils.quoteObject(key) + ' = null';
+    }
+
+    if (typeof $updates[ key ] == 'object' && 'type' in $updates[ key ]){
+      return utils.quoteObject(key) + ' = ( ' + queryBuilder( $updates[ key ], values ) + ' )';
+    }
     return utils.quoteObject(key) + ' = $' + values.push($updates[key]);
   });
 

--- a/test/update.js
+++ b/test/update.js
@@ -391,6 +391,60 @@ describe('Built-In Query Types', function(){
       );
     });
 
+    it('should update with expression', function() {
+      var query = builder.sql({
+        type: 'update'
+      , table: 'users'
+      , where: {
+          id: 7
+        }
+      , values: {
+          name: {
+            type: 'select'
+          , columns: ['name']
+          , table: 'users'
+          , limit: 1
+          }
+        }
+      });
+
+      assert.equal(
+        query.toString()
+      , 'update "users" set "name" = ( select "users"."name" from "users" limit $1 ) where "users"."id" = $2'
+      );
+
+      assert.deepEqual(
+        query.values
+      , [1, 7]
+      );
+    });
+
+    it('should update with function expression', function() {
+      var query = builder.sql({
+        type: 'update'
+      , table: 'users'
+      , where: {
+          id: 7
+        }
+      , values: {
+          name: {
+            type: 'lower'
+          , expression: 'users.name'
+          }
+        }
+      });
+
+      assert.equal(
+        query.toString()
+      , 'update "users" set "name" = ( lower( users.name ) ) where "users"."id" = $1'
+      );
+
+      assert.deepEqual(
+        query.values
+      , [7]
+      );
+    });
+
 
   });
 });


### PR DESCRIPTION
This is the query I am trying to run:
update tableName set title = CONVERT(_latin1 "密码不匹配"  USING utf8) where Id = 222;
This works fine while I am running it in mysql-server UI.

But when I am trying to do the same thing using mongo-sql specified method as :
title: { type: 'CONVERT', expression: '_latin1 \'密码不匹配\' USING utf8'}

It fails saying: 
Possibly unhandled Error: ER_BAD_FIELD_ERROR: Unknown column 'expression' in 'field list'
at Query.Sequence._packetToError

This is only happening while updating, while inserting it works fine.