### PR TITLE
HAVING in Postgresql

### DIFF
--- a/docs/query-helpers.md
+++ b/docs/query-helpers.md
@@ -371,6 +371,19 @@ Adds a group by clause. GROUP BY will condense into a single row all selected ro
 
 [Playground](http://mosql.j0.hn/#/snippets/19)
 
+### Helper: 'having'
+
+Adds a `having` conditional expression. This follows the same semantics as any other [conditional express](#helper-where). If the HAVING clause is present, it eliminates groups that do not satisfy the given condition.
+
+```javascript
+{
+  type: 'select'
+, table: 'users'
+, groupBy: ['id', 'name']
+, having: { $custom: ['lower(name) > $1', 'bob'] }
+}
+```
+
 ### Helper: 'ifExists'
 
 Adds IF EXISTS condition to [drop-table](./query-types.md#type-drop-table) and [alter-table](./query-types.md#type-alter-table) query types.

--- a/docs/query-types.md
+++ b/docs/query-types.md
@@ -30,10 +30,10 @@ __Definition:__
 ```
 {with} select {expression} {distinct} {columns} {over} {table} {alias}
 {joins} {join} {innerJoin} {leftJoin} {leftOuterJoin} {fullOuterJoin} {crossOuterJoin}
-{where} {groupBy} {order} {limit} {offset} {for}
+{where} {groupBy} {having} {order} {limit} {offset} {for}
 ```
 
-__Helpers Used__: [with](./query-helpers.md#helper-with), [expression](./query-helpers.md#helper-expression), [distinct](./query-helpers.md#helper-distinct), [columns](./query-helpers.md#helper-columns), [over](./query-helpers.md#helper-over), [table](./query-helpers.md#helper-table), [alias](./query-helpers.md#helper-alias), [joins](./query-helpers.md#helper-joins), [join](./query-helpers.md#helper-join), [innerJoin](./query-helpers.md#helper-innerjoin), [leftJoin](./query-helpers.md#helper-leftjoin), [leftOuterJoin](./query-helpers.md#helper-leftouterjoin), [fullOuterJoin](./query-helpers.md#helper-fullouterjoin), [crossOuterJoin](./query-helpers.md#helper-crossouterjoin), [where](./query-helpers.md#helper-where), [groupBy](./query-helpers.md#helper-groupby), [order](./query-helpers.md#helper-order), [limit](./query-helpers.md#helper-limit), [offset](./query-helpers.md#helper-offset), [for](./query-helpers.md#helper-for)
+__Helpers Used__: [with](./query-helpers.md#helper-with), [expression](./query-helpers.md#helper-expression), [distinct](./query-helpers.md#helper-distinct), [columns](./query-helpers.md#helper-columns), [over](./query-helpers.md#helper-over), [table](./query-helpers.md#helper-table), [alias](./query-helpers.md#helper-alias), [joins](./query-helpers.md#helper-joins), [join](./query-helpers.md#helper-join), [innerJoin](./query-helpers.md#helper-innerjoin), [leftJoin](./query-helpers.md#helper-leftjoin), [leftOuterJoin](./query-helpers.md#helper-leftouterjoin), [fullOuterJoin](./query-helpers.md#helper-fullouterjoin), [crossOuterJoin](./query-helpers.md#helper-crossouterjoin), [where](./query-helpers.md#helper-where), [groupBy](./query-helpers.md#helper-groupby), [having](./query-helpers.md#helper-having), [order](./query-helpers.md#helper-order), [limit](./query-helpers.md#helper-limit), [offset](./query-helpers.md#helper-offset), [for](./query-helpers.md#helper-for)
 
 ___Note:___ _The [where helper](./conditional-helpers.md) was sufficiently complex to warrant its own helper system._
 

--- a/helpers/query-types.js
+++ b/helpers/query-types.js
@@ -5,7 +5,7 @@ queryTypes.add( 'select', [
   '{with} select {expression} {distinct}'
 , '{columns} {over} {table} {alias}'
 , '{joins} {join} {innerJoin} {leftJoin} {leftOuterJoin} {fullOuterJoin} {crossOuterJoin}'
-, '{where} {groupBy} {window} {order} {limit} {offset} {for}'
+, '{where} {groupBy} {having} {window} {order} {limit} {offset} {for}'
 ].join(' '));
 
 queryTypes.add(

--- a/helpers/query/having.js
+++ b/helpers/query/having.js
@@ -1,0 +1,9 @@
+
+var helpers = require('../../lib/query-helpers');
+var conditionBuilder = require('../../lib/condition-builder');
+
+helpers.register('having', function(having, values, query){
+  var output = conditionBuilder(having, query.__defaultTable, values);
+  if (output.length > 0) output = 'having ' + output;
+  return output;
+});

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ require('./helpers/query/for');
 require('./helpers/query/from');
 require('./helpers/query/function');
 require('./helpers/query/group-by');
+require('./helpers/query/having');
 require('./helpers/query/if-exists');
 require('./helpers/query/if-not-exists');
 require('./helpers/query/joins');

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -1005,4 +1005,27 @@ describe('Conditions', function(){
     );
   });
 
+  it('having', function(){
+    var query = builder.sql({
+      type: 'select'
+    , table: 'users'
+    , groupBy: 'id'
+    , having: {
+        name: { $gt: 'Bob' }
+      }
+    });
+
+    assert.equal(
+      query.toString()
+    , [ 'select "users".* from "users" group by "users"."id" '
+      , 'having "users"."name" > $1'
+      ].join('')
+    );
+
+    assert.deepEqual(
+      query.values
+    , ['Bob']
+    );
+  });
+
 });


### PR DESCRIPTION
I am wondering if there is a reason why the `HAVING` conditions were not implemented for PG?
(http://www.postgresql.org/docs/9.4/static/sql-select.html)