### PR TITLE
Expression should support array syntax like $custom

### DIFF
--- a/helpers/query/expression.js
+++ b/helpers/query/expression.js
@@ -1,9 +1,12 @@
-
 var helpers = require('../../lib/query-helpers');
 var queryBuilder = require('../../lib/query-builder');
 
 helpers.register('expression', function(exp, values, query){
-  if (Array.isArray(exp)) return exp.join(', ');
+  if (Array.isArray(exp)) {
+    var expObj = { expression: exp[0], values: exp.slice(1) }
+    return helpers.get('expression').fn(expObj, values, query)
+  }
+
   if (query.type == 'insert' && typeof exp == 'object')
     return '(' + queryBuilder(exp, values) + ')';
   if (typeof exp == 'object'){

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,6 +2,34 @@ var assert  = require('assert');
 var builder = require('../');
 
 describe('Helpers', function(){
+  describe('Individual Helpers', function(){
+    it('expression: Array', function(){
+      var query = builder.sql({
+        expression: ['foo_bar($1, \'baz\', $2)', 100, 200]
+      })
+
+      assert.equal(query.toString(), 'foo_bar($1, \'baz\', $2)')
+
+      assert.deepEqual(query.values, [100, 200])
+    })
+
+    it('expression: Array should work in values into global context', function(){
+      var query = builder.sql({
+        type: 'select',
+        table: 'users',
+        where: { foo: 'bar' },
+        groupBy: [{ expression: ['foo_bar($1, \'baz\', $2)', 100, 200] }],
+      })
+
+      assert.equal(query.toString(), [
+        'select "users".* from "users"',
+        'where "users"."foo" = $1',
+        'group by foo_bar($2, \'baz\', $3)'
+      ].join(' '))
+
+      assert.deepEqual(query.values, ['bar', 100, 200])
+    })
+  })
 
   describe('Types', function(){
     it('should add a query type', function(){


### PR DESCRIPTION
```javascript
{ expression: ['generate_series($1, $2)', start, end] }
```

This deviates from the existing behavior to just join the array into a string.

This change will necessitate a major version bump.