### PR TITLE
typo on /docs/conditional-helpers.md

### DIFF
--- a/docs/conditional-helpers.md
+++ b/docs/conditional-helpers.md
@@ -440,7 +440,7 @@ __Example:__
 ```javascript
 var mosql = require('mongo-sql');
 
-mosql.condtionalHelpers.add('$years_ago', function(column, value, values, table){
+mosql.conditionalHelpers.add('$years_ago', function(column, value, values, table){
   return column + " >= now() - interval " + value + " year";
 });
 


### PR DESCRIPTION
It says `mosql.condtionalHelpers.add` when it should say `mosql.conditionalHelpers.add`.

That's all!