### PR TITLE
Fix null handling in condition builder so we get the right equality/inequality descriptors

### DIFF
--- a/helpers/conditional.js
+++ b/helpers/conditional.js
@@ -7,6 +7,18 @@
 var conditionals = require('../lib/conditional-helpers');
 var queryBuilder = require('../lib/query-builder');
 
+var valuesThatUseIsOrIsNot = [
+  'true', 'false', true, false, null
+]
+
+function getValueEqualityOperator(value) {
+  return valuesThatUseIsOrIsNot.indexOf(value) > -1 ? 'is' : '='
+}
+
+function getValueInequalityOperator(value) {
+  return valuesThatUseIsOrIsNot.indexOf(value) > -1 ? 'is not' : '!='
+}
+
 /**
  * Querying where column is equal to a value
  * @param column {String}  - Column name either table.column or column
@@ -15,7 +27,7 @@ var queryBuilder = require('../lib/query-builder');
 conditionals.add('$equals', function(column, value, values, collection, original){
   var equator = '=';
 
-  return column + ' ' + ((value == 'true' || value == 'false') ? 'is' : '=') + ' ' + value;
+  return column + ' ' + getValueEqualityOperator(value) + ' ' + value;
 });
 
 /**
@@ -24,7 +36,8 @@ conditionals.add('$equals', function(column, value, values, collection, original
  * @param value  {Mixed}   - What the column should be equal to
  */
 conditionals.add('$ne', function(column, value, values, collection, original){
-  return column + ' != ' + value;
+  console.log('CALLING $ne', column, value)
+  return column + ' ' + getValueInequalityOperator(value) + ' ' + value;
 });
 
 /**

--- a/lib/condition-builder.js
+++ b/lib/condition-builder.js
@@ -17,15 +17,7 @@ module.exports = function(where, table, values){
         continue;
       }
 
-      // If the value is null, send a $null helper through the condition builder
-      if ( where[key] === null ) {
-        var tmp = {};
-        tmp[key] = { $null: true };
-        conditions.push( buildConditions(tmp, condition, column, joiner) );
-        continue;
-      }
-
-      if (typeof where[key] == 'object' && !(where[key] instanceof Date) && !Buffer.isBuffer(where[key])) {
+      if (typeof where[key] == 'object' && !(where[key] instanceof Date) && !Buffer.isBuffer(where[key]) && where[key] !== null) {
 
         // Key is conditional block
         if (helpers.has(key)) {
@@ -60,7 +52,7 @@ module.exports = function(where, table, values){
         conditions.push(
           helpers.get(key).fn(
             column
-          , utils.parameterize(where[key], values)
+          , where[key] === null ? null : utils.parameterize(where[key], values)
           , values
           , table
           , where[key]
@@ -72,7 +64,7 @@ module.exports = function(where, table, values){
         conditions.push(
           helpers.get(condition).fn(
             column
-          , utils.parameterize(where[key], values)
+          , where[key] === null ? null : utils.parameterize(where[key], values)
           , values
           , table
           , where[key]
@@ -84,7 +76,7 @@ module.exports = function(where, table, values){
         conditions.push(
           helpers.get(condition).fn(
             utils.quoteObject(key, table)
-          , utils.parameterize(where[key], values)
+          , where[key] === null ? null : utils.parameterize(where[key], values)
           , values
           , table
           , where[key]

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -1049,4 +1049,44 @@ describe('Conditions', function(){
     );
   });
 
+  it('should handle nulls', function() {
+    var query = builder.sql({
+      type: 'select',
+      table: 'users',
+      where: {
+        email: { $ne: null }
+      }
+    })
+
+    assert.equal(
+      query.toString()
+    , 'select "users".* from "users" where "users"."email" is not null'
+    );
+
+    assert.deepEqual(
+      query.values
+    , []
+    );
+
+    query = builder.sql({
+      type: 'select',
+      table: 'users',
+      where: {
+        email: null,
+        $ne: { name: null },
+      }
+    })
+
+    assert.equal(
+      query.toString()
+    , 'select "users".* from "users" where "users"."email" is null '
+        + 'and "users"."name" is not null'
+    );
+
+    assert.deepEqual(
+      query.values
+    , []
+    );
+  })
+
 });


### PR DESCRIPTION
Entering the following mongo-sql query results in an unexpected query:
```json
{
  "type": "select",
  "table": "users",
  "where": {
    "email": { "$ne": null }
  }
}
```

Expected result:
```sql
select "users".* from "users" where "users"."email" is not null
```

Actual result:
```sql
select "users".* from "users" where "users"."email" is null
```