### PR TITLE
fix: ignore undefined values from  array

### DIFF
--- a/helpers/conditional.js
+++ b/helpers/conditional.js
@@ -113,7 +113,7 @@ conditionals.add('$ilike', function(column, value, values, collection, original)
  * Querying where column is in a set
  *
  * Values
- * - String, no explaination necessary
+ * - String, no explanation necessary
  * - Array, joins escaped values with a comma
  * - Function, executes function, expects string in correct format
  *  |- Useful for sub-queries
@@ -123,7 +123,7 @@ conditionals.add('$ilike', function(column, value, values, collection, original)
  */
 conditionals.add('$in', { cascade: false }, function(column, set, values, collection, original){
   if (Array.isArray(set)) {
-    return column + ' in (' + set.map( function(val){
+    return column + ' in (' + set.filter(val => val !== undefined).map( function(val){
       return '$' + values.push( val );
     }).join(', ') + ')';
   }

--- a/helpers/conditional.js
+++ b/helpers/conditional.js
@@ -123,11 +123,13 @@ conditionals.add('$ilike', function(column, value, values, collection, original)
  */
 conditionals.add('$in', { cascade: false }, function(column, set, values, collection, original){
   if (Array.isArray(set)) {
+    var hasNulls = set.indexOf(null) > -1;
+
     return column + ' in (' + set.filter(function(val) {
-      return val !== undefined;
+      return val !== undefined && val !== null;
     }).map( function(val){
       return '$' + values.push( val );
-    }).join(', ') + ')';
+    }).join(', ') + ')' + (hasNulls ? ' or ' + column + ' is null' : '');
   }
 
   return column + ' in (' + queryBuilder(set, values).toString() + ')';
@@ -146,13 +148,9 @@ conditionals.add('$in', { cascade: false }, function(column, set, values, collec
  * @param value  {Mixed}   - String|Array|Function
  */
 conditionals.add('$nin', { cascade: false }, function(column, set, values, collection, original){
-  if (Array.isArray(set)) {
-    return column + ' not in (' + set.map( function(val){
-      return '$' + values.push( val );
-    }).join(', ') + ')';
-  }
-
-  return column + ' not in (' + queryBuilder(set, values).toString() + ')';
+  return conditionals.get('$in').fn(column, set, values, collection, original)
+    .replace(/in/g, 'not in')
+    .replace(/is/g, 'is not');
 });
 
 /**

--- a/helpers/conditional.js
+++ b/helpers/conditional.js
@@ -123,7 +123,9 @@ conditionals.add('$ilike', function(column, value, values, collection, original)
  */
 conditionals.add('$in', { cascade: false }, function(column, set, values, collection, original){
   if (Array.isArray(set)) {
-    return column + ' in (' + set.filter(val => val !== undefined).map( function(val){
+    return column + ' in (' + set.filter(function(val) {
+      return val !== undefined;
+    }).map( function(val){
       return '$' + values.push( val );
     }).join(', ') + ')';
   }

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -403,12 +403,13 @@ describe('Conditions', function(){
     assert.equal(
       query.toString()
     , 'select "users".* from "users" where ' +
-      '"users"."id" in ($1, $2, $3, $4, $5)'
+      '"users"."id" in ($1, $2, $3) ' +
+      'or "users"."id" is null'
     );
 
     assert.deepEqual(
       query.values
-    , [1, 2, null, null, 3]
+    , [1, 2, 3]
     );
   });
 
@@ -457,6 +458,30 @@ describe('Conditions', function(){
       query.toString()
     , 'select "users".* from "users" where ' +
       '"users"."id" not in ($1, $2, $3)'
+    );
+
+    assert.deepEqual(
+      query.values
+    , [1, 2, 3]
+    );
+  });
+
+  it ('$nin array with undefined and null', function(){
+    var query = builder.sql({
+      type: 'select'
+    , table: 'users'
+    , where: {
+        id: {
+          $nin: [1, 2, undefined, null, null, 3]
+        }
+      }
+    });
+
+    assert.equal(
+      query.toString()
+    , 'select "users".* from "users" where ' +
+      '"users"."id" not in ($1, $2, $3) ' +
+      'or "users"."id" is not null'
     );
 
     assert.deepEqual(

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -389,6 +389,29 @@ describe('Conditions', function(){
     );
   });
 
+  it ('$in array with undefined and null', function(){
+    var query = builder.sql({
+      type: 'select'
+    , table: 'users'
+    , where: {
+        id: {
+          $in: [1, 2, undefined, null, null, 3]
+        }
+      }
+    });
+
+    assert.equal(
+      query.toString()
+    , 'select "users".* from "users" where ' +
+      '"users"."id" in ($1, $2, $3, $4, $5)'
+    );
+
+    assert.deepEqual(
+      query.values
+    , [1, 2, null, null, 3]
+    );
+  });
+
   it ('$nin', function(){
     var query = builder.sql({
       type: 'select'


### PR DESCRIPTION
Closes https://github.com/goodybag/mongo-sql/issues/163

`$in` will ignore `undefined` values now. As for `null` values there is no point in crossing them to single `null` until you got insane number of `null` in that array :D