### PR TITLE
Fix for $inc many columns

### DIFF
--- a/helpers/update.js
+++ b/helpers/update.js
@@ -12,14 +12,14 @@ var utils = require('../lib/utils');
  *  { $inc: { clicks: 1 } }
  * @param  {Object} Hash whose keys are the columns to inc and values are how much it will inc
  */
-helpers.add('$inc', function(value, values, collection){
-  var output = "";
-
-  for (var key in value){
-    output += utils.quoteObject(key) + ' = ' + utils.quoteObject(key, collection) + ' + $' + values.push(value[key]);
-  }
-
-  return output;
+helpers.add('$inc', function(value, values, collection) {
+  return Object.keys(value).map(key =>
+    utils.quoteObject(key) +
+    ' = ' +
+    utils.quoteObject(key, collection) +
+    ' + $' +
+    values.push(value[key])
+  ).join(', ');
 });
 
 /**

--- a/helpers/update.js
+++ b/helpers/update.js
@@ -13,13 +13,9 @@ var utils = require('../lib/utils');
  * @param  {Object} Hash whose keys are the columns to inc and values are how much it will inc
  */
 helpers.add('$inc', function(value, values, collection) {
-  return Object.keys(value).map(key =>
-    utils.quoteObject(key) +
-    ' = ' +
-    utils.quoteObject(key, collection) +
-    ' + $' +
-    values.push(value[key])
-  ).join(', ');
+  return Object.keys(value).map(function (key) {
+    return utils.quoteObject(key) + ' = ' + utils.quoteObject(key, collection) + ' + $' + values.push(value[key]);
+  }).join(', ');
 });
 
 /**

--- a/test/update.js
+++ b/test/update.js
@@ -166,6 +166,29 @@ describe('Built-In Query Types', function(){
       );
     });
 
+    it('$inc many columns', function(){
+      var query = builder.sql({
+        type: 'update'
+      , table: 'users'
+      , where: {
+          id: 7
+        }
+      , updates: {
+          $inc: { count: 5, age: 36 }
+        }
+      });
+
+      assert.equal(
+        query.toString()
+      , 'update "users" set "count" = "users"."count" + $1, "age" = "users"."age" + $2 where "users"."id" = $3'
+      );
+
+      assert.deepEqual(
+        query.values
+      , [5, 36, 7]
+      );
+    });
+
     it('$dec', function(){
       var query = builder.sql({
         type: 'update'
@@ -360,6 +383,29 @@ describe('Built-In Query Types', function(){
       assert.deepEqual(
         query.values
       , [5, 7]
+      );
+    });
+
+    it('$inc many columns', function(){
+      var query = builder.sql({
+        type: 'update'
+      , table: 'users'
+      , where: {
+          id: 7
+        }
+      , values: {
+          $inc: { count: 5, age: 36 }
+        }
+      });
+
+      assert.equal(
+        query.toString()
+      , 'update "users" set "count" = "users"."count" + $1, "age" = "users"."age" + $2 where "users"."id" = $3'
+      );
+
+      assert.deepEqual(
+        query.values
+      , [5, 36, 7]
       );
     });
 


### PR DESCRIPTION
Currently if you use the $inc helper for many columns there is no comma delimiter between the columns. 

```
var builder = require('mongo-sql');
var usersQuery = {
  type: 'update',
  table: 'users',
  where: { id: 7 },
  updates: { $inc: { hp: 5, hq: 4 } },
};
var result = builder.sql(usersQuery);
result.toString()
// update "users" set "hp" = "users"."hp" + $1"hq" = "users"."hq" + $2 where "users"."id" = $3
// SHOULD BE:
// update "users" set "hp" = "users"."hp" + $1, "hq" = "users"."hq" + $2 where "users"."id" = $3
