### PR TITLE
fix: Syntax error when { column: { $in: [null] } }

### DIFF
--- a/helpers/conditional.js
+++ b/helpers/conditional.js
@@ -125,11 +125,17 @@ conditionals.add('$in', { cascade: false }, function(column, set, values, collec
   if (Array.isArray(set)) {
     var hasNulls = set.indexOf(null) > -1;
 
-    return column + ' in (' + set.filter(function(val) {
+    var setNoNulls = set.filter(function(val) {
       return val !== undefined && val !== null;
-    }).map( function(val){
-      return '$' + values.push( val );
-    }).join(', ') + ')' + (hasNulls ? ' or ' + column + ' is null' : '');
+    })
+
+    if(setNoNulls.length > 0) {
+      return column + ' in (' + setNoNulls.map( function(val){
+        return '$' + values.push( val );
+      }).join(', ') + ')' + (hasNulls ? ' or ' + column + ' is null' : '')
+    }
+
+    return (hasNulls ? column + ' is null' : '');
   }
 
   return column + ' in (' + queryBuilder(set, values).toString() + ')';

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -413,6 +413,26 @@ describe('Conditions', function(){
     );
   });
 
+  it ('$in array with only null', function(){
+    var query = builder.sql({
+      type: 'select'
+    , table: 'users'
+    , where: {
+        id: {
+          $in: [null]
+        }
+      }
+    });
+
+    assert.equal(
+      query.toString()
+    , 'select "users".* from "users" where ' +
+      '"users"."id" is null'
+    );
+
+    assert.deepEqual(query.values, []);
+  });
+
   it ('$nin', function(){
     var query = builder.sql({
       type: 'select'
@@ -488,6 +508,26 @@ describe('Conditions', function(){
       query.values
     , [1, 2, 3]
     );
+  });
+
+  it ('$nin array with only null', function(){
+    var query = builder.sql({
+      type: 'select'
+    , table: 'users'
+    , where: {
+        id: {
+          $nin: [null]
+        }
+      }
+    });
+
+    assert.equal(
+      query.toString()
+    , 'select "users".* from "users" where ' +
+      '"users"."id" is not null'
+    );
+
+    assert.deepEqual(query.values , []);
   });
 
   it ('should allow an arbitrary amount of conditions', function(){


### PR DESCRIPTION
This commit fixes a bug introduced in v.5.0.0 where `{ column: { $in: [null] } }` is converted to `column in () or column is null` instead of `column is null`.