### PR TITLE
fix: Skip undefined values in update object

### DIFF
--- a/helpers/query/updates.js
+++ b/helpers/query/updates.js
@@ -11,6 +11,10 @@ queryTypes.register('updates', function($updates, values, query){
       return updateHelpers.get(key).fn($updates[key], values, query.__defaultTable);
     }
 
+    if ($updates[key] === undefined){
+      return null;
+    }
+
     if ($updates[key] === null){
       return utils.quoteObject(key) + ' = null';
     }
@@ -21,5 +25,5 @@ queryTypes.register('updates', function($updates, values, query){
     return utils.quoteObject(key) + ' = ' + utils.parameterize($updates[key], values);
   });
 
-  return result.length > 0 ? ('set ' + result.join(', ')) : '';
+  return result.length > 0 ? ('set ' + result.filter(function( x ){ return !!x; }).join(', ')) : '';
 });

--- a/test/update.js
+++ b/test/update.js
@@ -511,6 +511,25 @@ describe('Built-In Query Types', function(){
       );
     });
 
+    it('should skip undefined in update', function(){
+      var query = builder.sql({
+        type: 'update'
+      , table: 'users'
+      , values: {
+          name: 'Bob'
+        , email: undefined
+        }
+      });
 
+      assert.equal(
+        query.toString()
+      , 'update "users" set "name" = $1'
+      );
+
+      assert.deepEqual(
+        query.values
+      , ['Bob']
+      );
+    });
   });
 });


### PR DESCRIPTION
Current behaviour is an error `TypeError: Cannot read property '0' of undefined`