### PR TITLE
fix: Fix missing statement when  is empty array

### DIFF
--- a/helpers/conditional.js
+++ b/helpers/conditional.js
@@ -123,6 +123,10 @@ conditionals.add('$ilike', function(column, value, values, collection, original)
  */
 conditionals.add('$in', { cascade: false }, function(column, set, values, collection, original){
   if (Array.isArray(set)) {
+    if (set.length === 0) {
+      return 'false'
+    }
+
     var hasNulls = set.indexOf(null) > -1;
 
     var setNoNulls = set.filter(function(val) {

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -389,6 +389,29 @@ describe('Conditions', function(){
     );
   });
 
+  it ('$in empty array', function(){
+    var query = builder.sql({
+      type: 'select'
+    , table: 'users'
+    , where: {
+        id: {
+          $in: []
+        }
+      }
+    });
+
+    assert.equal(
+      query.toString()
+    , 'select "users".* from "users" where ' +
+      'false'
+    );
+
+    assert.deepEqual(
+      query.values
+    , []
+    );
+  });
+
   it ('$in array with undefined and null', function(){
     var query = builder.sql({
       type: 'select'
@@ -418,8 +441,8 @@ describe('Conditions', function(){
       type: 'select'
     , table: 'users'
     , where: {
-	'true': 'true',
-        id: {
+        'true': 'true'
+      , id: {
           $in: [1, 2, undefined, null, null, 3]
         }
       }


### PR DESCRIPTION
In previous versions an empty array caused a syntax error (`select "users".* from "users" where "users"."id" in ()`).

In the current version, the query becomes `select "users".* from "users" `.

I think that this behaviour, returning zero rows, is what should be expected, not returning all rows.