### PR TITLE
Make $nin true for empty array

### DIFF
--- a/helpers/conditional.js
+++ b/helpers/conditional.js
@@ -159,6 +159,9 @@ conditionals.add('$in', { cascade: false }, function(column, set, values, collec
  * @param value  {Mixed}   - String|Array|Function
  */
 conditionals.add('$nin', { cascade: false }, function(column, set, values, collection, original){
+  if (Array.isArray(set) && set.length === 0) {
+    return 'true'
+  }
   return conditionals.get('$in').fn(column, set, values, collection, original)
     .replace(new RegExp(column + ' in', 'g'), column + ' not in')
     .replace(new RegExp(column + ' is', 'g'), column + ' is not');

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -606,7 +606,7 @@ describe('Conditions', function(){
     assert.deepEqual(query.values , []);
   });
 
-  it ('$nin empty array should evaluate to true', function(){
+  it ('$nin for an empty array should evaluate to true', function(){
     var query = builder.sql({
       type: 'select'
     , table: 'users'

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -606,6 +606,24 @@ describe('Conditions', function(){
     assert.deepEqual(query.values , []);
   });
 
+  it ('$nin empty array should evaluate to true', function(){
+    var query = builder.sql({
+      type: 'select'
+    , table: 'users'
+    , where: {
+        id: {
+          $nin: []
+        }
+      }
+    });
+    assert.equal(
+      query.toString()
+    , 'select "users".* from "users" where ' +
+      'true'
+    );
+    assert.deepEqual(query.values , []);
+  });  
+
   it ('$nin with subquery', function(){
     var query = builder.sql({
       type: 'select'


### PR DESCRIPTION
If `$in` returns `'false'` for an empty array, shouldn't `$nin` return `'true'` for an empty array?